### PR TITLE
bug/#299_queried-c-document-property

### DIFF
--- a/src/DocumentsRepository/Traits/QueryableDocumentsRepositoryTrait.spec.ts
+++ b/src/DocumentsRepository/Traits/QueryableDocumentsRepositoryTrait.spec.ts
@@ -5720,6 +5720,9 @@ describe( module( "carbonldp/DocumentsRepository/Traits/QueryableDocumentsReposi
 								"${ C.checksum }": [ {
 									"@value": "1-12345"
 								} ],
+								"${ C.document }": [ {
+									"@id": "https://example.com/resource/child1/"
+								} ],
 								"https://schema.org/property-1": [ {
 									"@value": "value 1"
 								} ],
@@ -5751,6 +5754,9 @@ describe( module( "carbonldp/DocumentsRepository/Traits/QueryableDocumentsReposi
 								],
 								"${ C.checksum }": [ {
 									"@value": "2-12345"
+								} ],
+								"${ C.document }": [ {
+									"@id": "https://example.com/resource/child2/"
 								} ],
 								"https://schema.org/property-1": [ {
 									"@value": "value 2"
@@ -7111,6 +7117,9 @@ describe( module( "carbonldp/DocumentsRepository/Traits/QueryableDocumentsReposi
 								"${ C.checksum }": [ {
 									"@value": "1-12345"
 								} ],
+								"${ C.document }": [ {
+									"@id": "https://example.com/resource/child1/"
+								} ],
 								"https://schema.org/property-1": [ {
 									"@value": "value 1"
 								} ],
@@ -7142,6 +7151,9 @@ describe( module( "carbonldp/DocumentsRepository/Traits/QueryableDocumentsReposi
 								],
 								"${ C.checksum }": [ {
 									"@value": "2-12345"
+								} ],
+								"${ C.document }": [ {
+									"@id": "https://example.com/resource/child2/"
 								} ],
 								"https://schema.org/property-1": [ {
 									"@value": "value 2"

--- a/src/QueryDocuments/QueryResultCompacter.ts
+++ b/src/QueryDocuments/QueryResultCompacter.ts
@@ -161,9 +161,11 @@ export class QueryResultCompacter {
 		const targetSchema:DigestedObjectSchema = queryProperty.getSchemaFor( node );
 		const pointerLibrary:PointerLibrary = __createPointerLibrary( compactionMap, document );
 
-		// Avoid compaction of c:checksum
 		const targetNode:RDFNode = {
 			...node,
+			// Avoid compaction of c:document
+			[ C.document ]: null,
+			// Avoid compaction of c:checksum
 			[ C.checksum ]: null,
 		};
 


### PR DESCRIPTION
- Fixed [#299](https://github.com/CarbonLDP/carbonldp-js-sdk/issues/299) - No compaction of `c:document` in queried resources