### PR TITLE
task/#401_fix-static-and-instance-links-in-documentation

### DIFF
--- a/src/Context/Context.ts
+++ b/src/Context/Context.ts
@@ -80,12 +80,11 @@ export interface Context<REGISTRY extends RegisteredPointer | undefined = Regist
 	/**
 	 * Extends the schema of the type specified.
 	 *
-	 * The signature behaves as the previous one but uses {@link ModelSchema#TYPE `ModelSchema.TYPE`}
-	 * as the type and {@link ModelSchema#SCHEMA `ModelSchema.SCHEMA`} as the schema data extender.
+	 * The signature behaves as the previous one but uses {@link ModelSchema#TYPE}
+	 * as the type and {@link ModelSchema#SCHEMA} as the schema data extender.
 	 *
 	 * @param modelSchema The object with the type and the schema to extend.
 	 */
-	// TODO: Fix link syntax
 	extendObjectSchema( modelSchema:ModelSchema ):this;
 	/**
 	 * Extends a multiple of typed schemas using the interface {@link ModelSchema}

--- a/src/DocumentsRepository/Utils.ts
+++ b/src/DocumentsRepository/Utils.ts
@@ -61,9 +61,8 @@ export function _parseResourceParams<T>( this:void, resource:ResolvablePointer, 
 
 /**
  * Returns a function that can parse a {@link HTTPError} into a {@link ErrorResponse} inside a rejected Promise.
- * @param registry The registry from where to get the information to convert the {@link HTTPError#response `HTTPError.response`}'s data.
+ * @param registry The registry from where to get the information to convert the {@link HTTPError#response}'s data.
  */
-// TODO: Fix link syntax
 export function _getErrorResponseParserFn( this:void, registry:DocumentsRegistry ):( error:HTTPError | Error ) => Promise<never> {
 	return ( error:HTTPError | Error ) => {
 		if( !("response" in error) ) return Promise.reject( error );

--- a/src/Fragment/Fragment.ts
+++ b/src/Fragment/Fragment.ts
@@ -35,121 +35,103 @@ export interface Fragment extends TransientFragment, QueryablePointer {
 
 
 	/**
-	 * Accessor to the {@link Document#$get `Document.$get()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$get `Document.$get()`}
+	 * Accessor to the {@link Document#$get} method of the document where the fragment belongs to.
+	 * @see {@link Document#$get}
 	 */
-	// TODO: Fix link syntax
 	$get<T extends object>( queryBuilderFn:( queryBuilder:QueryDocumentBuilder ) => QueryDocumentBuilder ):Promise<T & Document>;
 	/**
-	 * Accessor to the {@link Document#$get `Document.$get()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$get `Document.$get()`}
+	 * Accessor to the {@link Document#$get} method of the document where the fragment belongs to.
+	 * @see {@link Document#$get}
 	 */
-	// TODO: Fix link syntax
 	$get<T extends object>( requestOptions?:GETOptions, queryBuilderFn?:( queryBuilder:QueryDocumentBuilder ) => QueryDocumentBuilder ):Promise<T & Document>;
 	/**
-	 * Accessor to the {@link Document#$get `Document.$get()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$get `Document.$get()`}
+	 * Accessor to the {@link Document#$get} method of the document where the fragment belongs to.
+	 * @see {@link Document#$get}
 	 */
-	// TODO: Fix link syntax
 	$get<T extends object>( uri:string, queryBuilderFn:( queryBuilder:QueryDocumentBuilder ) => QueryDocumentBuilder ):Promise<T & Document>;
 	/**
-	 * Accessor to the {@link Document#$get `Document.$get()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$get `Document.$get()`}
+	 * Accessor to the {@link Document#$get} method of the document where the fragment belongs to.
+	 * @see {@link Document#$get}
 	 */
-	// TODO: Fix link syntax
 	$get<T extends object>( uri:string, requestOptions?:GETOptions, queryBuilderFn?:( queryBuilder:QueryDocumentBuilder ) => QueryDocumentBuilder ):Promise<T & Document>;
 
 	/**
-	 * Accessor to the {@link Document#$resolve `Document.$resolve()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$resolve `Document.$resolve()`}
+	 * Accessor to the {@link Document#$resolve} method of the document where the fragment belongs to.
+	 * @see {@link Document#$resolve}
 	 */
-	// TODO: Fix link syntax
 	$resolve<T extends object>( requestOptions?:GETOptions, queryBuilderFn?:( queryBuilder:QueryDocumentBuilder ) => QueryDocumentBuilder ):Promise<T & this & Document>;
 	/**
-	 * Accessor to the {@link Document#$resolve `Document.$resolve()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$resolve `Document.$resolve()`}
+	 * Accessor to the {@link Document#$resolve} method of the document where the fragment belongs to.
+	 * @see {@link Document#$resolve}
 	 */
-	// TODO: Fix link syntax
 	$resolve<T extends object>( queryBuilderFn?:( queryBuilder:QueryDocumentBuilder ) => QueryDocumentBuilder ):Promise<T & this & Document>;
 	/**
-	 * Accessor to the {@link Document#$resolve `Document.$resolve()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$resolve `Document.$resolve()`}
+	 * Accessor to the {@link Document#$resolve} method of the document where the fragment belongs to.
+	 * @see {@link Document#$resolve}
 	 */
-	// TODO: Fix link syntax
 	$resolve<T extends object>( document:Document, queryBuilderFn:( queryBuilder:QueryDocumentBuilder ) => QueryDocumentBuilder ):Promise<T & Document>;
 	/**
-	 * Accessor to the {@link Document#$resolve `Document.$resolve()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$resolve `Document.$resolve()`}
+	 * Accessor to the {@link Document#$resolve} method of the document where the fragment belongs to.
+	 * @see {@link Document#$resolve}
 	 */
-	// TODO: Fix link syntax
 	$resolve<T extends object>( document:Document, requestOptions?:GETOptions, queryBuilderFn?:( queryBuilder:QueryDocumentBuilder ) => QueryDocumentBuilder ):Promise<T & Document>;
 
 
 	/**
-	 * Accessor to the {@link Document#$exists `Document.$exists()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$exists `Document.$exists()`}
+	 * Accessor to the {@link Document#$exists} method of the document where the fragment belongs to.
+	 * @see {@link Document#$exists}
 	 */
-	// TODO: Fix link syntax
 	$exists( requestOptions?:RequestOptions ):Promise<boolean>;
 	/**
-	 * Accessor to the {@link Document#$exists `Document.$exists()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$exists `Document.$exists()`}
+	 * Accessor to the {@link Document#$exists} method of the document where the fragment belongs to.
+	 * @see {@link Document#$exists}
 	 */
-	// TODO: Fix link syntax
 	$exists( uri:string, requestOptions?:RequestOptions ):Promise<boolean>;
 
 
 	/**
-	 * Accessor to the {@link Document#$refresh `Document.$refresh()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$refresh `Document.$refresh()`}
+	 * Accessor to the {@link Document#$refresh} method of the document where the fragment belongs to.
+	 * @see {@link Document#$refresh}
 	 */
-	// TODO: Fix link syntax
 	$refresh<T extends object>( requestOptions?:RequestOptions ):Promise<T & this & Document>;
 	/**
-	 * Accessor to the {@link Document#$refresh `Document.$refresh()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$refresh `Document.$refresh()`}
+	 * Accessor to the {@link Document#$refresh} method of the document where the fragment belongs to.
+	 * @see {@link Document#$refresh}
 	 */
-	// TODO: Fix link syntax
 	$refresh<T extends object>( document:Document, requestOptions?:RequestOptions ):Promise<T & Document>;
 
 	/**
-	 * Accessor to the {@link Document#$save `Document.$save()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$save `Document.$save()`}
+	 * Accessor to the {@link Document#$save} method of the document where the fragment belongs to.
+	 * @see {@link Document#$save}
 	 */
-	// TODO: Fix link syntax
 	$save<T extends object>( requestOptions?:RequestOptions ):Promise<T & this & Document>;
 	/**
-	 * Accessor to the {@link Document#$save `Document.$save()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$save `Document.$save()`}
+	 * Accessor to the {@link Document#$save} method of the document where the fragment belongs to.
+	 * @see {@link Document#$save}
 	 */
-	// TODO: Fix link syntax
 	$save<T extends object>( document:Document, requestOptions?:RequestOptions ):Promise<T & Document>;
 
 	/**
-	 * Accessor to the {@link Document#$saveAndRefresh `Document.$saveAndRefresh()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$saveAndRefresh `Document.$saveAndRefresh()`}
+	 * Accessor to the {@link Document#$saveAndRefresh} method of the document where the fragment belongs to.
+	 * @see {@link Document#$saveAndRefresh}
 	 */
-	// TODO: Fix link syntax
 	$saveAndRefresh<T extends object>( requestOptions?:RequestOptions ):Promise<T & this & Document>;
 	/**
-	 * Accessor to the {@link Document#$saveAndRefresh `Document.$saveAndRefresh()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$saveAndRefresh `Document.$saveAndRefresh()`}
+	 * Accessor to the {@link Document#$saveAndRefresh} method of the document where the fragment belongs to.
+	 * @see {@link Document#$saveAndRefresh}
 	 */
-	// TODO: Fix link syntax
 	$saveAndRefresh<T extends object>( document:Document, requestOptions?:RequestOptions ):Promise<T & Document>;
 
 
 	/**
-	 * Accessor to the {@link Document#$delete `Document.$delete()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$delete `Document.$delete()`}
+	 * Accessor to the {@link Document#$delete} method of the document where the fragment belongs to.
+	 * @see {@link Document#$delete}
 	 */
-	// TODO: Fix link syntax
 	$delete( requestOptions?:RequestOptions ):Promise<void>;
 	/**
-	 * Accessor to the {@link Document#$delete `Document.$delete()`} method of the document where the fragment belongs to.
-	 * @see {@link Document#$delete `Document.$delete()`}
+	 * Accessor to the {@link Document#$delete} method of the document where the fragment belongs to.
+	 * @see {@link Document#$delete}
 	 */
-	// TODO: Fix link syntax
 	$delete( uri:string, requestOptions?:RequestOptions ):Promise<void>;
 }
 

--- a/src/GeneralRegistry/TypedModelDecorator.ts
+++ b/src/GeneralRegistry/TypedModelDecorator.ts
@@ -3,9 +3,8 @@ import { ModelDecorator } from "../Model/ModelDecorator";
 
 /**
  * Object that has implements a model decorator for an specific type
- * defined by the property {@link TypedModelDecorator#TYPE `TypedModelDecorator.TYPE`}.
+ * defined by the property {@link TypedModelDecorator#TYPE}.
  */
-// TODO: Fix link syntax
 export interface TypedModelDecorator extends ModelDecorator<any, any> {
 	/**
 	 * The type associated to the model decorator methods.

--- a/src/HTTP/Request.ts
+++ b/src/HTTP/Request.ts
@@ -48,10 +48,9 @@ export interface GETOptions extends RequestOptions {
 }
 
 /**
- * Object used by {@link RequestUtils#setRetrievalPreferences `RequestUtils.setRetrievalPreferences()`}
+ * Object used by {@link RequestUtils.setRetrievalPreferences}
  * which specifies the behaviour of a request when using an `ldp:Container` interaction model.
  */
-// TODO: Fix link syntax
 export interface RetrievalPreferences {
 	/**
 	 * Prefer URIs that indicates some specific information should be returned in the request's response.

--- a/src/JSONLD/JSONLDParser.ts
+++ b/src/JSONLD/JSONLDParser.ts
@@ -7,10 +7,9 @@ import { JSONLDProcessor } from "./JSONLDProcessor";
  */
 export class JSONLDParser extends JSONParser implements Parser<object[]> {
 	/**
-	 * Parse the string provided using the {@link JSONLDProcessor#expand `JSONLDProcessor.expand()`}` method.
+	 * Parse the string provided using the {@link JSONLDProcessor.expand} method.
 	 * @param input The JSON-LD string to parse.
 	 */
-	// TODO: Fix link syntax
 	parse( input:string ):Promise<object[]> {
 		return super.parse( input ).then( JSONLDProcessor.expand );
 	}

--- a/src/LDPatch/DeltaCreator.ts
+++ b/src/LDPatch/DeltaCreator.ts
@@ -83,7 +83,7 @@ export class DeltaCreator {
 	}
 
 	/**
-	 * Returns the LD Patch string of the resources set in {@link DeltaCreator.addResource()}.
+	 * Returns the LD Patch string of the resources set in {@link DeltaCreator#addResource}.
 	 */
 	getPatch():string {
 		const patch:LDPatchToken = new LDPatchToken();

--- a/src/LDPatch/Tokens.ts
+++ b/src/LDPatch/Tokens.ts
@@ -6,9 +6,8 @@ import { isNumber } from "../Utils";
 /**
  * The tokens that states a change in the data.
  *
- * Used in the {@link LDPatchToken#statements `LDPatchToken.statements`}.
+ * Used in the {@link LDPatchToken#statements}.
  */
-// TODO: Fix link syntax
 export type StatementToken = AddToken | DeleteToken | UpdateListToken;
 
 /**

--- a/src/QueryDocuments/QuerySubPropertyData.ts
+++ b/src/QueryDocuments/QuerySubPropertyData.ts
@@ -8,9 +8,8 @@ import { QueryPropertyType } from "./QueryPropertyType";
 
 
 /**
- * Base data for create a sub-property with {@link QueryProperty#_addSubProperty `QueryProperty._addSubProperty()`}.
+ * Base data for create a sub-property with {@link QueryProperty#_addSubProperty}.
  */
-// TODO: Fix link syntax
 export interface QuerySubPropertyData {
 	queryContainer?:QueryContainer;
 	parent?:QueryProperty;

--- a/src/QueryDocuments/QueryVariable.ts
+++ b/src/QueryDocuments/QueryVariable.ts
@@ -4,9 +4,8 @@ import { VariableToken } from "sparqler/tokens";
 /**
  * Class used to represent an property inside the query.
  *
- * Instances of the the class are create internally by {@link QueryContainer#getVariable `QueryContainer.getVariable()`}.
+ * Instances of the the class are create internally by {@link QueryContainer#getVariable}.
  */
-// TODO: Fix link syntax
 export class QueryVariable extends VariableToken {
 	readonly name!:string;
 	readonly index:number;
@@ -29,3 +28,4 @@ export class QueryVariable extends VariableToken {
 			return super.toString();
 	}
 }
+q

--- a/src/QueryDocuments/QueryableProperty.ts
+++ b/src/QueryDocuments/QueryableProperty.ts
@@ -14,9 +14,8 @@ import { _getBestType } from "./Utils";
 /**
  * Metadata of a resource that has been queried.
  *
- * It is used in {@link QueryablePointer#$_queryableMetadata `QueryablePointer.$_queryableMetadata`}.
+ * It is used in {@link QueryablePointer#$_queryableMetadata}.
  */
-// TODO: Fix link syntax
 export class QueryableProperty {
 	readonly definition:DigestedObjectSchemaProperty;
 	readonly pathBuilderFn?:( pathBuilder:PathBuilder ) => Path;

--- a/src/Registry/Registry.ts
+++ b/src/Registry/Registry.ts
@@ -89,19 +89,17 @@ export interface Registry<MODEL extends RegisteredPointer = RegisteredPointer> e
 	getPointers( local:true ):MODEL[];
 
 	/**
-	 * Removes the resource identified by the provided string ID or {@link Pointer#$id `Pointer.$id`}, from the first occurrence in the registry hierarchy.
+	 * Removes the resource identified by the provided string ID or {@link Pointer#$id}, from the first occurrence in the registry hierarchy.
 	 * Returns true if the resource could be removed, false otherwise.
 	 * @param idOrPointer ID or Pointer to be removed.
 	 */
-	// TODO: Fix link syntax
 	removePointer( idOrPointer:string | RegisteredPointer ):boolean;
 	/**
-	 * Removes the resource identified by the provided string ID or {@link Pointer#$id `Pointer.$id`}, from the first occurrence in the registry hierarchy.
+	 * Removes the resource identified by the provided string ID or {@link Pointer#$id}, from the first occurrence in the registry hierarchy.
 	 * Returns true if the resource could be removed, false otherwise.
 	 * @param idOrPointer ID or Pointer to be removed.
 	 * @param local Flag to ignore hierarchy and only remove from the current registry.
 	 */
-	// TODO: Fix link syntax
 	removePointer( idOrPointer:string | RegisteredPointer, local:true ):boolean;
 
 
@@ -194,19 +192,17 @@ export interface $Registry<MODEL extends RegisteredPointer = RegisteredPointer> 
 	$getPointers( local:true ):MODEL[];
 
 	/**
-	 * Removes the resource identified by the provided string ID or {@link Pointer#$id `Pointer.$id`}, from the first occurrence in the registry hierarchy.
+	 * Removes the resource identified by the provided string ID or {@link Pointer#$id}, from the first occurrence in the registry hierarchy.
 	 * Returns true if the resource could be removed, false otherwise.
 	 * @param idOrPointer ID or Pointer to be removed.
 	 */
-	// TODO: Fix link syntax
 	$removePointer( idOrPointer:string | RegisteredPointer ):boolean;
 	/**
-	 * Removes the resource identified by the provided string ID or {@link Pointer#$id `Pointer.$id`}, from the first occurrence in the registry hierarchy.
+	 * Removes the resource identified by the provided string ID or {@link Pointer#$id}, from the first occurrence in the registry hierarchy.
 	 * Returns true if the resource could be removed, false otherwise.
 	 * @param idOrPointer ID or Pointer to be removed.
 	 * @param local Flag to ignore hierarchy and only remove from the current registry.
 	 */
-	// TODO: Fix link syntax
 	$removePointer( idOrPointer:string | RegisteredPointer, local:true ):boolean;
 
 


### PR DESCRIPTION
Static methods are now rendered and documented following the following [JSDoc Rules](https://jsdoc.app/about-namepaths.html):
- `MyClass.staticMethod`
- `MyClass#instanceMethod`

And rest parameters have been corrected in the @params tags.