### PR TITLE
bug/#420_fix-typescipt-compilation-in-webstorm-intellij

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
 		"sourceMap": true,
 		"importHelpers": true
 	},
+	"compileOnSave": false,
 	"exclude": [
 		"build",
 		"dist",


### PR DESCRIPTION
Resolves #420

Turn off the "compileOnSave" flag in order to avoid automatic compilation in both WebStorm and IntelliJ