### PR TITLE
Fix 360 - IDAlreadyInUseError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 	  
 ### Fixed
 
+- [#360](https://github.com/CarbonLDP/carbonldp-js-sdk/issues/360) - Fix `$IDAlreadyInUseError` error when executing `onChildCreated` using real-time capabilities and when requesting a `$get` of a non-existent resource
 - [#391](https://github.com/CarbonLDP/carbonldp-js-sdk/issues/391) - Adding properties with `undefined`, `null` and/or `[]` (empty array) triggers a patch request on save, even though this doesn't represent RDF changes
 - [#392](https://github.com/CarbonLDP/carbonldp-js-sdk/issues/392) - Assigning a property that only wraps its previous value into an array triggers a patch request on save, even though this doesn't represent RDF changes
 

--- a/src/Document/TransientDocument.ts
+++ b/src/Document/TransientDocument.ts
@@ -5,6 +5,7 @@ import { Context } from "../Context/Context";
 import { DocumentsRegistry } from "../DocumentsRegistry/DocumentsRegistry";
 
 import { IllegalArgumentError } from "../Errors/IllegalArgumentError";
+import { IDAlreadyInUseError } from "../Errors/IDAlreadyInUseError";
 
 import { TransientFragment } from "../Fragment/TransientFragment";
 
@@ -267,6 +268,11 @@ export const TransientDocument:{
 			if( isString( isOrObject ) ) id = isOrObject;
 
 			const $id:string = id ? __getLabelFrom( id ) : __getObjectId( object );
+
+			if( this.$hasPointer( $id, true )) {
+				throw new IDAlreadyInUseError( `"${ $id }" is already being used.` );
+			}
+
 			const fragment:T & TransientFragment = this.$_addPointer( Object
 				.assign<T, Pointer>( object, { $id } )
 			);

--- a/src/DocumentsRepository/Utils.ts
+++ b/src/DocumentsRepository/Utils.ts
@@ -68,6 +68,7 @@ export function _getErrorResponseParserFn( this:void, registry:DocumentsRegistry
 	return ( error:HTTPError | Error ) => {
 		if( !("response" in error) ) return Promise.reject( error );
 		if( !error.response.data ) return Promise.reject( error );
+		if( error.response.status >= 400 && error.response.status <= 499 ) return Promise.reject( error );
 
 		return new JSONLDParser()
 			.parse( error.response.data )

--- a/src/DocumentsRepository/Utils.ts
+++ b/src/DocumentsRepository/Utils.ts
@@ -68,7 +68,6 @@ export function _getErrorResponseParserFn( this:void, registry:DocumentsRegistry
 	return ( error:HTTPError | Error ) => {
 		if( !("response" in error) ) return Promise.reject( error );
 		if( !error.response.data ) return Promise.reject( error );
-		if( error.response.status >= 400 && error.response.status <= 499 ) return Promise.reject( error );
 
 		return new JSONLDParser()
 			.parse( error.response.data )

--- a/src/Registry/Registry.spec.ts
+++ b/src/Registry/Registry.spec.ts
@@ -75,14 +75,14 @@ describe( "Registry", () => {
 				} ).toThrowError( IllegalArgumentError, `"id" is out of scope.` );
 			} );
 
-			it( "should return resource", () => {
+			it( "should return the given resource even though the ID is already in use", () => {
 				const registry:Registry<RegisteredPointer> = createMock( {} );
 
 				registry.__resourcesMap.set( "id", RegisteredPointer.create( { $registry: registry } ) );
 
-				expect( () => {
-					registry._addPointer( { $id: "id" } );
-				} ).toEqual( jasmine.any( Function ) );
+				expect(
+					registry._addPointer( { $id: "id" } )
+				).toEqual( registry.__resourcesMap.get("id")! );
 			} );
 
 			it( "should return the same object reference", () => {
@@ -1062,13 +1062,13 @@ describe( "$Registry", () => {
 				} ).toThrowError( IllegalArgumentError, `"id" is out of scope.` );
 			} );
 
-			it( "should throw error when ID already taken", () => {
+			it( "should return the given resource even though the ID is already in use", () => {
 				const registry:$Registry<RegisteredPointer> = create$Mock( {} );
 				registry.$__resourcesMap.set( "id", RegisteredPointer.create( { $registry: registry } ) );
 
-				expect( () => {
-					registry.$_addPointer( { $id: "id" } );
-				} ).toEqual( jasmine.any( Function ) );
+				expect(
+					registry.$_addPointer( { $id: "id" } )
+				).toEqual( registry.$__resourcesMap.get( "id" )! );
 			} );
 
 			it( "should return the same object reference", () => {

--- a/src/Registry/Registry.spec.ts
+++ b/src/Registry/Registry.spec.ts
@@ -75,15 +75,15 @@ describe( "Registry", () => {
 				} ).toThrowError( IllegalArgumentError, `"id" is out of scope.` );
 			} );
 
-			it( "should throw error when ID already taken", () => {
+			it( "should return resource", () => {
 				const registry:Registry<RegisteredPointer> = createMock( {} );
+
 				registry.__resourcesMap.set( "id", RegisteredPointer.create( { $registry: registry } ) );
 
 				expect( () => {
 					registry._addPointer( { $id: "id" } );
-				} ).toThrowError( IDAlreadyInUseError, `"id" is already being used.` );
+				} ).toEqual( jasmine.any( Function ) );
 			} );
-
 
 			it( "should return the same object reference", () => {
 				const registry:Registry<RegisteredPointer> = createMock( {} );
@@ -1068,9 +1068,8 @@ describe( "$Registry", () => {
 
 				expect( () => {
 					registry.$_addPointer( { $id: "id" } );
-				} ).toThrowError( IDAlreadyInUseError, `"id" is already being used.` );
+				} ).toEqual( jasmine.any( Function ) );
 			} );
-
 
 			it( "should return the same object reference", () => {
 				const registry:$Registry<RegisteredPointer> = create$Mock( {} );

--- a/src/Registry/Registry.ts
+++ b/src/Registry/Registry.ts
@@ -1,4 +1,3 @@
-import { IDAlreadyInUseError } from "../Errors/IDAlreadyInUseError";
 import { IllegalArgumentError } from "../Errors/IllegalArgumentError";
 
 import { BiModelDecorator } from "../Model/BiModelDecorator";

--- a/src/Registry/Registry.ts
+++ b/src/Registry/Registry.ts
@@ -389,14 +389,15 @@ export const Registry:{
 			const localID:string = __getLocalID( this, pointer.$id );
 
 			const resourcesMap:Map<string, RegisteredPointer> = __getResourcesMaps( this );
-			if( resourcesMap.has( localID ) ) throw new IDAlreadyInUseError( `"${ pointer.$id }" is already being used.` );
 
 			const resource:T & RegisteredPointer = __getDecorator( this )
 				.decorate( Object.assign<T, BaseRegisteredPointer>( pointer, {
 					$registry: this,
 				} ) );
 
-			resourcesMap.set( localID, resource );
+			if( !resourcesMap.has( localID ) ) {
+				resourcesMap.set( localID, resource );
+			}
 
 			return resource;
 		},


### PR DESCRIPTION
Fix #360 $IDAlreadyInUseError error when executing onChildCreated using real-time capabilities and when requesting a $get of a non-existent resource

Fix #379